### PR TITLE
Updated to latest babel modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "6.5.1",
-    "babel-cli": "6.5.1",
-    "babel-preset-es2015": "6.5.0",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.4",
+    "babel-plugin-transform-export-extensions": "^6.5.0",
+    "babel-preset-es2015": "^6.6.0",
     "chai": "3.5.0",
-    "chai-immutable": "1.5.3",
+    "chai-immutable": "1.5.4",
     "mocha": "2.4.5"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "socket.io": "1.4.5"
   },
   "babel": {
+    "plugins": ["transform-export-extensions"],
     "presets": ["es2015"]
   }
 }


### PR DESCRIPTION
When working through the tutorial the latest version of babel has nerfed the "default" [module export behaviour](https://github.com/Microsoft/TypeScript/issues/5565#issuecomment-155226290).

It requires adding the [transform export extensions](http://babeljs.io/docs/plugins/transform-export-extensions/) plugin, otherwise the following will not work:

``` javascript
// core.js
export function setEntries(state, entries) {
  return state.set('entries', entries);
}

//core_spec.js
import {List as list, Map as map} from 'immutable';
import {expect} from 'chai';
import {setEntries} from '../src/core';

describe('application logic', () => {
  describe('setEntries', () => {
    it('adds the entries to the state', () => {
      const entries = list.of('Trainspotting', '28 Days Later');
      const state = map();
      const nextState = setEntries(state, entries); // setEntries is undefined unless the transform export extensions plugin is enabled

      expect(nextState).to.equal(map({
        entries: list.of('Trainspotting', '28 Days Later')
      }));
    });
  });
});
```
